### PR TITLE
Data from tables with binary fields are not being exported in mysql

### DIFF
--- a/src/Engine/MysqlEngine.php
+++ b/src/Engine/MysqlEngine.php
@@ -64,7 +64,7 @@ class MysqlEngine extends BaseEngine
     {
         $databaseName = $this->_database['database'];
         $baseArgs = $this->_getBaseArguments();
-        $command = "mysqldump $baseArgs $databaseName | grep -v '/*!50013 DEFINER'";
+        $command = "mysqldump $baseArgs $databaseName | grep -v -a '/*!50013 DEFINER'";
         if (!empty($file)) {
             $command .= " > $file";
         }


### PR DESCRIPTION
When I executed the command bin/cake fixture_import dump the inserts containing binary fields are being removed. It is due to the grep command, but adding the -a option forces it to be interpreted as text and thus avoids lines being removed with binary content.
Example:
![compare-export-files](https://user-images.githubusercontent.com/41989865/76759758-3e7dd780-6784-11ea-9af1-5478022d04d8.png)

