### PR TITLE
Let the app create dump using extended inserts

### DIFF
--- a/src/Engine/MysqlEngine.php
+++ b/src/Engine/MysqlEngine.php
@@ -10,6 +10,7 @@
  */
 namespace CakeDC\DbTest\Engine;
 
+use Cake\Core\Configure;
 use Cake\Log\Log;
 
 class MysqlEngine extends BaseEngine
@@ -63,7 +64,11 @@ class MysqlEngine extends BaseEngine
     {
         $databaseName = $this->_database['database'];
         $baseArgs = $this->_getBaseArguments();
-        $command = "mysqldump --extended-insert=FALSE $baseArgs $databaseName | grep -v -a '/*!50013 DEFINER'";
+        $command = "mysqldump";
+        if (Configure::read('DbTest.dumpExtendedInserts') !== true) {
+            $command .= " --extended-insert=FALSE";
+        }
+        $command .= " $baseArgs $databaseName | grep -v -a '/*!50013 DEFINER'";
         if (!empty($file)) {
             $command .= " > $file";
         }


### PR DESCRIPTION
Extend inserts works better with big test databases (multiple inserts can make it very slow)